### PR TITLE
Add properties to manifest for npm 7 and 8

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -7,6 +7,8 @@ const fs = require('fs')
 const {
   PACKAGE_NAME = pkg.name,
   PACKAGE_VERSION = pkg.version,
+  PACKAGE_DEPENDENCIES = pkg.dependencies,
+  PACKAGE_DEVDEPENDENCIES = pkg.devDependencies,
   KEYGEN_ACCOUNT_ID,
   KEYGEN_PRODUCT_ID,
   KEYGEN_PRODUCT_TOKEN,
@@ -176,13 +178,18 @@ async function publishManifestForPackage() {
   // Attempt to merge previous manifest's versions to ensure we maintain history
   const prev = await getManifestForPackage(PACKAGE_NAME)
   const next = {
+    _id: `${PACKAGE_NAME}`,
     name: PACKAGE_NAME,
     'dist-tags': {
       latest: PACKAGE_VERSION,
     },
-    version: PACKAGE_VERSION,
     versions: Object.assign({}, prev?.versions, {
       [PACKAGE_VERSION]: {
+        _id: `${PACKAGE_NAME}@${PACKAGE_VERSION}`,
+        name: `${PACKAGE_NAME}`,
+        version: PACKAGE_VERSION,
+        dependencies: PACKAGE_DEPENDENCIES,
+        devDependencies: PACKAGE_DEVDEPENDENCIES,
         dist: {
           tarball: `https://api.keygen.sh/v1/accounts/${KEYGEN_ACCOUNT_ID}/artifacts/${PACKAGE_NAME}/${PACKAGE_VERSION}.tgz`,
           integrity: `sha512-${digest}`,


### PR DESCRIPTION
Before:

If a package included `dependencies` or `devDependencies` and one attempted to install using `npm i @private-scope/private-package` using npm >= 7.0 the `package.json` would be updated with an odd version such as:

```json
...
"@private-scope/private-package": "npm:null@*"
...
``` 
and child dependencies would not install. 

After:

Package versions are added and child dependencies are installed as desired.